### PR TITLE
revert the changes

### DIFF
--- a/media/libstagefright/filters/SimpleFilter.h
+++ b/media/libstagefright/filters/SimpleFilter.h
@@ -33,11 +33,11 @@ public:
 
     virtual status_t configure(const sp<AMessage> &msg);
 
-    virtual status_t start() { return OK; };
-    virtual void reset() {};
-    virtual status_t setParameters(const sp<AMessage> &msg) { return OK; };
+    virtual status_t start() = 0;
+    virtual void reset() = 0;
+    virtual status_t setParameters(const sp<AMessage> &msg) = 0;
     virtual status_t processBuffers(
-            const sp<MediaCodecBuffer> &srcBuffer, const sp<MediaCodecBuffer> &outBuffer) { return OK; };
+            const sp<MediaCodecBuffer> &srcBuffer, const sp<MediaCodecBuffer> &outBuffer) = 0;
 
 protected:
     int32_t mWidth, mHeight;


### PR DESCRIPTION
The original change (2c340284ae191f52d1a4751f94fb039c81a7f0ae) was
made just to work-around compiler's error.
But now with new clang, this change is not needed.

Signed-off-by: Wang Chen <wangchen20@iscas.ac.cn>